### PR TITLE
fixes clojure.tools.namespace.repl/refresh-all

### DIFF
--- a/resources/sql/firebird.sql
+++ b/resources/sql/firebird.sql
@@ -42,16 +42,7 @@ matching (:i:entity-idfield, :i:target-idfield)
 -- MIGRATIONS --
 
 -- :snip column-def
-/* :require [specomatic.spec :as-alias sp]
-            [specomatic-db.db.migration :as migration]
-            [specomatic-db.db.firebird.util :refer [firebirdsql]] */
-:i:name
-/*~ (condp = (:type params)
-      ::sp/integer "integer"
-      'integer? "integer"
-      'string? "varchar(255)"
-      'my-boolean? "char(1)"
-      (migration/sql-type firebirdsql (:type params))) ~*/
+:i:name :sql:type
 
 -- :snip ref-column-def
 :i:name integer

--- a/resources/sql/postgres.sql
+++ b/resources/sql/postgres.sql
@@ -42,28 +42,14 @@ on conflict (:i:entity-idfield, :i:target-idfield) do nothing
 -- MIGRATIONS --
 
 -- :snip column-def
-/* :require [specomatic.spec :as-alias sp]
-            [specomatic-db.db.migration :as migration]
-            [specomatic-db.db.firebird.util :refer [firebirdsql]] */
-:i:name
-/*~ (condp = (:type params)
-      ::sp/integer "integer"
-      'integer? "integer"
-      'string? "varchar(255)"
-      'my-boolean? "char(1)"
-      (migration/sql-type firebirdsql (:type params))) ~*/
+:i:name :sql:type
 
 -- :snip ref-column-def
 :i:name integer
 
 -- :snip id-column-def
 /* :require [specomatic.spec :as-alias sp] */
-:i:name
-/*~ (condp = (:type params)
-      ::sp/integer "serial primary key"
-      'integer? "serial primary key"
-      "serial primary key") ~*/
-
+:i:name serial primary key
 
 -- :name ensure-table-transaction :!
 -- :doc ensure transaction table exists

--- a/src/specomatic_db/db/firebird/migration.clj
+++ b/src/specomatic_db/db/firebird/migration.clj
@@ -9,7 +9,8 @@
    [specomatic-db.db.generic       :as db-generic]
    [specomatic-db.db.migration     :as migration]
    [specomatic.core                :as sc]
-   [specomatic.field-def           :as sf]))
+   [specomatic.field-def           :as sf]
+   [specomatic.spec                :as sp]))
 
 (defmethod migration/column-def firebirdsql
   [db schema table-name field-keyword
@@ -27,7 +28,7 @@
                         :column   column-name
                         :target   (cnv/etype->table-name db target (sc/etype-def schema target))}})))
     {:main (first (db-firebird/column-def {:name (cnv/field->column-name db field-keyword field-def)
-                                           :type (migration/column-type field-def)}))}))
+                                           :type (migration/sql-type firebirdsql (sf/dispatch field-def))}))}))
 
 (defn- constraints-ddl
   [table-name existing-constraints constraints-params]
@@ -154,3 +155,11 @@
 (defmethod migration/clear-transaction-system-txid! firebirdsql
   [db]
   (db-firebird/clear-transaction-system-txid db))
+
+(defmethod migration/sql-type [firebirdsql ::sp/integer]
+  [_ _]
+  "integer")
+
+(defmethod migration/sql-type [firebirdsql 'integer?]
+  [_ _]
+  "integer")

--- a/src/specomatic_db/db/migration.clj
+++ b/src/specomatic_db/db/migration.clj
@@ -14,9 +14,9 @@
   get-dbtype)
 
 (defmulti sql-type
-  "Returns the sql type for a database type and spec."
-  (fn [dbtype field-spec]
-    [dbtype field-spec]))
+  "Returns the sql type for a database type and field spec dispatch value (keyword or description)."
+  (fn [dbtype dispatch]
+    [dbtype dispatch]))
 
 (defmethod sql-type :default
   [_ _]
@@ -52,13 +52,6 @@
 (defmulti clear-transaction-system-txid!
   "Clears all system txids from the transaction table."
   get-dbtype)
-
-(defn column-type
-  "Returns the type to pass to column-def snippet"
-  [field-def]
-  (if (sf/reference? field-def)
-    :reference
-    (sf/dispatch field-def)))
 
 (defn- diff-etypes
   [db tables existing-constraints schema etypes-and-reference-colls]


### PR DESCRIPTION
clojure.tools.namespace.repl/refresh-all gets confused by some clojure expressions in hugsql. Moved sql type logic into multimethod implementations, which is cleaner anyway